### PR TITLE
LazyInteractor

### DIFF
--- a/Sources/LazyInteractor.swift
+++ b/Sources/LazyInteractor.swift
@@ -21,7 +21,7 @@ class LazyInteractor<InteractorType: Interactor>: Interactor {
     }
     
     func execute(request: InteractorType.Request) {
-        
+        self.getInteractor().execute(request)
     }
     
 }

--- a/Sources/LazyInteractor.swift
+++ b/Sources/LazyInteractor.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+class LazyInteractor<InteractorType: Interactor>: Interactor {
+    
+    private(set) var lazyInstance: InteractorType?
+    
+    init(factory:(Void -> InteractorType)) {
+        
+    }
+    
+    func execute(request: InteractorType.Request) {
+        
+    }
+    
+}

--- a/Sources/LazyInteractor.swift
+++ b/Sources/LazyInteractor.swift
@@ -3,9 +3,21 @@ import Foundation
 class LazyInteractor<InteractorType: Interactor>: Interactor {
     
     private(set) var lazyInstance: InteractorType?
+    private let factory: (Void -> InteractorType)
     
     init(factory:(Void -> InteractorType)) {
+        self.factory = factory
+    }
+    
+    func getInteractor() -> InteractorType {
+        if let instance = lazyInstance {
+            return instance
+        }
         
+        let instance = factory()
+        self.lazyInstance = instance
+        
+        return instance
     }
     
     func execute(request: InteractorType.Request) {

--- a/Tests/InteractorExecuterTests.swift
+++ b/Tests/InteractorExecuterTests.swift
@@ -88,36 +88,35 @@ class InteractorTests: XCTestCase {
         XCTAssertEqual(errorMessageFromFirstRequest, expected)
     }
     
-}
-
-
-// MARK: Test Interactors
-
-class TestIntactor {
-    init() {
-        print("initT")
-    }
-    var numberOfExceuteCalls = 0
     
-    func testExecute() {
-        numberOfExceuteCalls += 1
-    }
-}
-
-class FirstInteractor: TestIntactor, Interactor {
-    class Request: InteractorRequest<NSString> {
+    // MARK: Test Interactors
+    
+    class TestInteractor {
+        var numberOfExceuteCalls = 0
+        
+        func testExecute() {
+            numberOfExceuteCalls += 1
+        }
     }
     
-    func execute(request: Request) {
-        self.testExecute()
-    }
-}
-
-class SecondInteractor: TestIntactor, Interactor {
-    class Request: InteractorRequest<NSString> {
+    class FirstInteractor: TestInteractor, Interactor {
+        class Request: InteractorRequest<NSString> {
+        }
+        
+        func execute(request: Request) {
+            self.testExecute()
+        }
     }
     
-    func execute(request: Request) {
-        self.testExecute()
+    class SecondInteractor: TestInteractor, Interactor {
+        class Request: InteractorRequest<NSString> {
+        }
+        
+        func execute(request: Request) {
+            self.testExecute()
+        }
     }
+    
 }
+
+

--- a/Tests/InteractorExecuterTests.swift
+++ b/Tests/InteractorExecuterTests.swift
@@ -39,6 +39,7 @@ class InteractorTests: XCTestCase {
         
         // Assert
         XCTAssertEqual(firstInteractor.numberOfExceuteCalls, 1)
+        XCTAssert(firstInteractor.executedRequest === firstRequest)
     }
     
     func testExecute_withTwoInteractors_executeOnSecond_callsExecuteOnSecondInteractor() {
@@ -51,6 +52,7 @@ class InteractorTests: XCTestCase {
         
         // Assert
         XCTAssertEqual(secondInteractor.numberOfExceuteCalls, 1)
+        XCTAssert(secondInteractor.executedRequest === secondRequest)
     }
     
     func testExecute_withTwoInteractors_executeOnBoth_callsExecuteOnEachInteractor() {
@@ -64,7 +66,10 @@ class InteractorTests: XCTestCase {
         
         // Assert
         XCTAssertEqual(firstInteractor.numberOfExceuteCalls, 1)
+        XCTAssert(firstInteractor.executedRequest === firstRequest)
+        
         XCTAssertEqual(secondInteractor.numberOfExceuteCalls, 1)
+        XCTAssert(secondInteractor.executedRequest === secondRequest)
     }
     
     func testExecute_withUnknownRequest_callsErrorOnRequest() {
@@ -91,29 +96,29 @@ class InteractorTests: XCTestCase {
     
     // MARK: Test Interactors
     
-    class TestInteractor {
+   class FirstInteractor: Interactor {
         var numberOfExceuteCalls = 0
+        var executedRequest: Request?
         
-        func testExecute() {
-            numberOfExceuteCalls += 1
+        class Request: InteractorRequest<NSString> {
+        }
+        
+    func execute(request: Request) {
+        self.numberOfExceuteCalls += 1
+        self.executedRequest = request
         }
     }
     
-    class FirstInteractor: TestInteractor, Interactor {
+    class SecondInteractor: Interactor {
+        var numberOfExceuteCalls = 0
+        var executedRequest: Request?
+        
         class Request: InteractorRequest<NSString> {
         }
         
         func execute(request: Request) {
-            self.testExecute()
-        }
-    }
-    
-    class SecondInteractor: TestInteractor, Interactor {
-        class Request: InteractorRequest<NSString> {
-        }
-        
-        func execute(request: Request) {
-            self.testExecute()
+            self.numberOfExceuteCalls += 1
+            self.executedRequest = request
         }
     }
     

--- a/Tests/LazyInteractorTests.swift
+++ b/Tests/LazyInteractorTests.swift
@@ -3,25 +3,46 @@ import XCTest
 
 class LazyInteractorTests: XCTestCase {
     
+    let testDependency = "testDependency"
+    let testFactory = {return TestInteractor(dependency: "testDependency")}
+    var lazyInteractor: LazyInteractor<TestInteractor>!
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        lazyInteractor = LazyInteractor(factory: testFactory)
     }
     
-    // MARK: Init
+    // MARK: init()
     
     func testInit_doesNotInitializeLazyInstance()
     {
-        // Arrange
-        let factory = {return TestInteractor(dependency: "")}
-        
-        // Act
-        let lazyInteractor = LazyInteractor(factory: factory)
-        
         // Assert
         XCTAssertNil(lazyInteractor.lazyInstance)
     }
     
+    // MARK: getInteractor()
+    
+    func testGetInteractor_returnsInstanceBuiltWithFactory()
+    {
+        // Act
+        let interactor = lazyInteractor.getInteractor()
+        
+        // Assert
+        XCTAssertEqual(interactor.dependency, testDependency)
+    }
+    
+    
+    func testGetInteractor_calledTwice_doesNotCreateNewInstance()
+    {
+        // Act
+        let firstInteractor = lazyInteractor.getInteractor()
+        let secondInteractor = lazyInteractor.getInteractor()
+        
+        // Assert
+        XCTAssert(firstInteractor === secondInteractor)
+    }
     
     
     // MARK: Test Interactors

--- a/Tests/LazyInteractorTests.swift
+++ b/Tests/LazyInteractorTests.swift
@@ -44,11 +44,29 @@ class LazyInteractorTests: XCTestCase {
         XCTAssert(firstInteractor === secondInteractor)
     }
     
+    // MARK: execute()
+    
+    func testExceute_callsExecuteOfInteractor()
+    {
+        // Arrange
+        let request = TestInteractor.Request()
+        
+        // Act
+        lazyInteractor.execute(request)
+        
+        // Assert
+        let interactor = lazyInteractor.getInteractor()
+        XCTAssertEqual(interactor.numberOfExceuteCalls, 1)
+        XCTAssert(interactor.executedRequest === request)
+    }
+    
     
     // MARK: Test Interactors
     
     class TestInteractor: Interactor {
         let dependency: String
+        var numberOfExceuteCalls = 0
+        var executedRequest: Request?
         
         init(dependency: String) {
             self.dependency = dependency
@@ -58,6 +76,8 @@ class LazyInteractorTests: XCTestCase {
         }
     
         func execute(request: Request) {
+            self.numberOfExceuteCalls += 1
+            self.executedRequest = request
         }
     }
 

--- a/Tests/LazyInteractorTests.swift
+++ b/Tests/LazyInteractorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import ACInteractor
+
+class LazyInteractorTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    // MARK: Init
+    
+    func testInit_doesNotInitializeLazyInstance()
+    {
+        // Arrange
+        let factory = {return TestInteractor(dependency: "")}
+        
+        // Act
+        let lazyInteractor = LazyInteractor(factory: factory)
+        
+        // Assert
+        XCTAssertNil(lazyInteractor.lazyInstance)
+    }
+    
+    
+    
+    // MARK: Test Interactors
+    
+    class TestInteractor: Interactor {
+        let dependency: String
+        
+        init(dependency: String) {
+            self.dependency = dependency
+        }
+    
+        class Request: InteractorRequest<NSString> {
+        }
+    
+        func execute(request: Request) {
+        }
+    }
+
+}

--- a/Xcode/ACInteractor.xcodeproj/project.pbxproj
+++ b/Xcode/ACInteractor.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		173A77D21D3849E200FF88BA /* ACInteractor.h in Headers */ = {isa = PBXBuildFile; fileRef = 173A77431D3849E100FF88BA /* ACInteractor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		17567E551D3A61C900C464BB /* InteractorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17567E541D3A61C900C464BB /* InteractorError.swift */; };
 		17567E591D3A640000C464BB /* InteractorErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17567E581D3A640000C464BB /* InteractorErrorTests.swift */; };
+		17B0BF701D3CD057004AA98B /* LazyInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B0BF6F1D3CD057004AA98B /* LazyInteractor.swift */; };
+		17B0BF721D3CD0A9004AA98B /* LazyInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B0BF711D3CD0A9004AA98B /* LazyInteractorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +40,8 @@
 		173A77D11D3849E200FF88BA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		17567E541D3A61C900C464BB /* InteractorError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InteractorError.swift; sourceTree = "<group>"; };
 		17567E581D3A640000C464BB /* InteractorErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InteractorErrorTests.swift; sourceTree = "<group>"; };
+		17B0BF6F1D3CD057004AA98B /* LazyInteractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyInteractor.swift; sourceTree = "<group>"; };
+		17B0BF711D3CD0A9004AA98B /* LazyInteractorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyInteractorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +89,7 @@
 				173A77391D3844D400FF88BA /* InteractorRequest.swift */,
 				17567E541D3A61C900C464BB /* InteractorError.swift */,
 				173A77381D3844D400FF88BA /* InteractorExecuter.swift */,
+				17B0BF6F1D3CD057004AA98B /* LazyInteractor.swift */,
 			);
 			name = Sources;
 			path = ../Sources;
@@ -95,6 +100,7 @@
 			children = (
 				173A77401D38461D00FF88BA /* InteractorExecuterTests.swift */,
 				17567E581D3A640000C464BB /* InteractorErrorTests.swift */,
+				17B0BF711D3CD0A9004AA98B /* LazyInteractorTests.swift */,
 			);
 			name = Tests;
 			path = ../Tests;
@@ -221,6 +227,7 @@
 				17567E551D3A61C900C464BB /* InteractorError.swift in Sources */,
 				173A773C1D3844D400FF88BA /* InteractorExecuter.swift in Sources */,
 				173A773D1D3844D400FF88BA /* InteractorRequest.swift in Sources */,
+				17B0BF701D3CD057004AA98B /* LazyInteractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,6 +235,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				17B0BF721D3CD0A9004AA98B /* LazyInteractorTests.swift in Sources */,
 				173A77411D38461D00FF88BA /* InteractorExecuterTests.swift in Sources */,
 				17567E591D3A640000C464BB /* InteractorErrorTests.swift in Sources */,
 			);


### PR DESCRIPTION
Implementation for lazy initialization of Interactors.
Takes a factory closure to initialize the Interactor.
Closure will be used to initialize the Interactor on first execute() function call.
