### PR TITLE
onCompleteVoid() function

### DIFF
--- a/Sources/ACInteractor/InteractorRequest.swift
+++ b/Sources/ACInteractor/InteractorRequest.swift
@@ -14,3 +14,9 @@ open class InteractorRequest<T>: InteractorRequestProtocol {
     public var onError:((InteractorError) -> Void)?
     public var onComplete:((Response) -> Void)?
 }
+
+public extension InteractorRequest where Response == Void  {
+    public func onCompleteVoid() {
+        onComplete?(())
+    }
+}

--- a/Tests/ACInteractorTests/InteractorRequestTests.swift
+++ b/Tests/ACInteractorTests/InteractorRequestTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import ACInteractor
+
+class InteractorRequestTests: XCTestCase {
+    
+    var onCompleteWasCalled = false
+    
+    func testOnCompleteVoid_callsOnComplete() {
+        // Arrange
+        let voidRequest = InteractorRequest<Void>()
+        var onCompleteWasCalled = false
+        voidRequest.onComplete = { _ in onCompleteWasCalled = true }
+        
+        // Act
+        voidRequest.onCompleteVoid()
+        
+        // Assert
+        XCTAssert(onCompleteWasCalled)
+    }
+    
+}


### PR DESCRIPTION
Adds a `onCompleteVoid()` function for InteractorRequests of type `Void`.
This should simply the completion call, since you can not just write `request.onComplete?()`, because Swift 4 explicitly requires a parameter of type `Void`, which is an empty tuple `()`.
```
let voidRequest = InteractorRequest<Void>()
voidRequest.onComplete?(())

// New
voidRequest.onCompleteVoid()
```