### PR TITLE
InteractorSpy

### DIFF
--- a/Sources/ACInteractor/InteractorSpy.swift
+++ b/Sources/ACInteractor/InteractorSpy.swift
@@ -43,4 +43,30 @@ class InteractorSpy<Request: InteractorRequestProtocol>: Interactor {
         }
     }
     
+    // MARK: - Response Helper
+    
+    var returnsResponse: Request.Response? {
+        get {
+            return returnsResponses.first
+        }
+        set {
+            returnsResponses.removeAll()
+            if let response = newValue {
+                returnsResponses.append(response)
+            }
+        }
+    }
+    
+    var returnsError: InteractorError? {
+        get {
+            return returnsErrors.first
+        }
+        set {
+            returnsErrors.removeAll()
+            if let error = newValue {
+                returnsErrors.append(error)
+            }
+        }
+    }
+    
 }

--- a/Sources/ACInteractor/InteractorSpy.swift
+++ b/Sources/ACInteractor/InteractorSpy.swift
@@ -31,6 +31,12 @@ class InteractorSpy<Request: InteractorRequestProtocol>: Interactor {
     
     // MARK: - Request Count
     
+    var lastRequest: Request? {
+        get {
+            return executedRequests.last
+        }
+    }
+    
     var isCalledOnce: Bool {
         get {
             return executedRequests.count == 1

--- a/Sources/ACInteractor/InteractorSpy.swift
+++ b/Sources/ACInteractor/InteractorSpy.swift
@@ -10,7 +10,7 @@ class InteractorSpy<Request: InteractorRequestProtocol>: Interactor {
     private(set) var executedRequests = [Request]()
     
     func execute(_ request: Request) {
-        
+        executedRequests.append(request)
     }
     
 }

--- a/Sources/ACInteractor/InteractorSpy.swift
+++ b/Sources/ACInteractor/InteractorSpy.swift
@@ -29,4 +29,18 @@ class InteractorSpy<Request: InteractorRequestProtocol>: Interactor {
         }
     }
     
+    // MARK: - Request Count
+    
+    var isCalledOnce: Bool {
+        get {
+            return executedRequests.count == 1
+        }
+    }
+    
+    var isNeverCalled: Bool {
+        get {
+            return executedRequests.count == 0
+        }
+    }
+    
 }

--- a/Sources/ACInteractor/InteractorSpy.swift
+++ b/Sources/ACInteractor/InteractorSpy.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+class InteractorSpy<Request: InteractorRequestProtocol>: Interactor {
+    
+    var returnsResponses = [Request.Response]()
+    var returnsErrors = [InteractorError]()
+    
+    let noError = InteractorError(message: "no error")
+    
+    private(set) var executedRequests = [Request]()
+    
+    func execute(_ request: Request) {
+        
+    }
+    
+}

--- a/Sources/ACInteractor/InteractorSpy.swift
+++ b/Sources/ACInteractor/InteractorSpy.swift
@@ -14,12 +14,16 @@ class InteractorSpy<Request: InteractorRequestProtocol>: Interactor {
         
         if let error = returnsErrors.first {
             returnsErrors.remove(at: 0)
-            request.onError?(error)
-            return
+            
+            if error != noError {
+                request.onError?(error)
+                return
+            }
         }
         
         if let response = returnsResponses.first {
             returnsResponses.remove(at: 0)
+            
             request.onComplete?(response)
             return
         }

--- a/Sources/ACInteractor/InteractorSpy.swift
+++ b/Sources/ACInteractor/InteractorSpy.swift
@@ -12,14 +12,16 @@ class InteractorSpy<Request: InteractorRequestProtocol>: Interactor {
     func execute(_ request: Request) {
         executedRequests.append(request)
         
-        if let response = returnsResponses.first {
-            returnsResponses.remove(at: 0)
-            request.onComplete?(response)
-        }
-        
         if let error = returnsErrors.first {
             returnsErrors.remove(at: 0)
             request.onError?(error)
+            return
+        }
+        
+        if let response = returnsResponses.first {
+            returnsResponses.remove(at: 0)
+            request.onComplete?(response)
+            return
         }
     }
     

--- a/Sources/ACInteractor/InteractorSpy.swift
+++ b/Sources/ACInteractor/InteractorSpy.swift
@@ -11,6 +11,16 @@ class InteractorSpy<Request: InteractorRequestProtocol>: Interactor {
     
     func execute(_ request: Request) {
         executedRequests.append(request)
+        
+        if let response = returnsResponses.first {
+            returnsResponses.remove(at: 0)
+            request.onComplete?(response)
+        }
+        
+        if let error = returnsErrors.first {
+            returnsErrors.remove(at: 0)
+            request.onError?(error)
+        }
     }
     
 }

--- a/Tests/ACInteractorTests/InteractorSpyTests.swift
+++ b/Tests/ACInteractorTests/InteractorSpyTests.swift
@@ -109,4 +109,23 @@ class InteractorSpyTests: XCTestCase {
         XCTAssert(secondRequestError == nil)
     }
     
+    func testExecute_callsOnComplete_whenNoErrorConstantIsUsed() {
+        // Arrange
+        let firstResponse = SampleResponse()
+        let secondResponse = SampleResponse()
+        spy.returnsResponses = [firstResponse, secondResponse]
+        spy.returnsErrors = [spy.noError, testError]
+        
+        // Act
+        spy.execute(firstRequest)
+        spy.execute(secondRequest)
+        
+        // Assert
+        XCTAssert(firstRequestResponse === firstResponse)
+        XCTAssert(firstRequestError == nil)
+        
+        XCTAssert(secondRequestResponse == nil)
+        XCTAssert(secondRequestError === testError)
+    }
+    
 }

--- a/Tests/ACInteractorTests/InteractorSpyTests.swift
+++ b/Tests/ACInteractorTests/InteractorSpyTests.swift
@@ -16,6 +16,8 @@ class InteractorSpyTests: XCTestCase {
     var firstRequestError: InteractorError?
     var secondRequestError: InteractorError?
     
+    let testError = InteractorError(message: "test error")
+    
     override func setUp() {
         super.setUp()
         
@@ -84,6 +86,27 @@ class InteractorSpyTests: XCTestCase {
         // Assert
         XCTAssert(firstRequestError === firstError)
         XCTAssert(secondRequestError === secondError)
+    }
+    
+    // MARK: - Mixed Responses and Errors
+    
+    func testExecute_callsOnComplete_afterAllErrorsHaveBeenReturned() {
+        // Arrange
+        let firstResponse = SampleResponse()
+        let secondResponse = SampleResponse()
+        spy.returnsResponses = [firstResponse, secondResponse]
+        spy.returnsErrors = [testError]
+        
+        // Act
+        spy.execute(firstRequest)
+        spy.execute(secondRequest)
+        
+        // Assert
+        XCTAssert(firstRequestResponse == nil)
+        XCTAssert(firstRequestError === testError)
+        
+        XCTAssert(secondRequestResponse === firstResponse)
+        XCTAssert(secondRequestError == nil)
     }
     
 }

--- a/Tests/ACInteractorTests/InteractorSpyTests.swift
+++ b/Tests/ACInteractorTests/InteractorSpyTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import ACInteractor
+
+class InteractorSpyTests: XCTestCase {
+    
+    class SampleRequest: InteractorRequest<SampleResponse> {}
+    class SampleResponse {}
+    
+    let spy = InteractorSpy<SampleRequest>()
+    
+    let firstRequest = SampleRequest()
+    let secondRequest = SampleRequest()
+    let firstResponse = SampleResponse()
+    let secondResponse = SampleResponse()
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    // MARK: - Requests
+    
+    func testExecutedRequests_returnsExecutedRequests() {
+        // Arrange
+        spy.execute(firstRequest)
+        spy.execute(secondRequest)
+        
+        // Act
+        let executedRequests = spy.executedRequests
+        
+        // Assert
+        XCTAssertEqual(executedRequests.count, 2)
+        XCTAssert(executedRequests.first === firstRequest)
+        XCTAssert(executedRequests.last === secondRequest)
+    }
+    
+    // MARK: - Response
+    
+    // MARK: - Error Handling
+    
+}

--- a/Tests/ACInteractorTests/InteractorSpyTests.swift
+++ b/Tests/ACInteractorTests/InteractorSpyTests.swift
@@ -168,4 +168,59 @@ class InteractorSpyTests: XCTestCase {
             XCTAssertEqual(isCalledOnce, test.result)
         }
     }
+    
+    // MARK: - Response Helper
+    
+    func testReturnsResponse_returnsFirstStoredResponse() {
+        // Arrange
+        let firstResponse = SampleResponse()
+        let secondResponse = SampleResponse()
+        spy.returnsResponses = [firstResponse, secondResponse]
+        
+        // Act
+        let response = spy.returnsResponse
+        
+        // Assert
+        XCTAssert(response === firstResponse)
+    }
+    
+    func testSetReturnsResponse_storesResponse_overridesExistingOnes() {
+        // Arange
+        spy.returnsResponses = [SampleResponse(), SampleResponse()]
+        let newResponse = SampleResponse()
+        
+        // Act
+        spy.returnsResponse = newResponse
+        
+        // Assert
+        XCTAssert(spy.returnsResponses.first === newResponse)
+        XCTAssertEqual(spy.returnsResponses.count, 1)
+    }
+    
+    func testReturnsError_returnsFirstStoredError() {
+        // Arange
+        let firstError = InteractorError()
+        let secondError = InteractorError()
+        spy.returnsErrors = [firstError, secondError]
+        
+        // Act
+        let error = spy.returnsError
+        
+        // Assert
+        XCTAssert(error === firstError)
+    }
+    
+    func testSetReturnsError_storesError_overridesExistingOnes() {
+        // Arange
+        spy.returnsErrors = [InteractorError(), InteractorError()]
+        let newError = InteractorError()
+        
+        // Act
+        spy.returnsError = newError
+        
+        // Assert
+        XCTAssert(spy.returnsErrors.first === newError)
+        XCTAssertEqual(spy.returnsErrors.count, 1)
+    }
+    
 }

--- a/Tests/ACInteractorTests/InteractorSpyTests.swift
+++ b/Tests/ACInteractorTests/InteractorSpyTests.swift
@@ -54,6 +54,18 @@ class InteractorSpyTests: XCTestCase {
         XCTAssert(executedRequests.last === secondRequest)
     }
     
+    func testLastRequest_returnsLastExecutedRequest() {
+        // Arrange
+        spy.execute(firstRequest)
+        spy.execute(secondRequest)
+        
+        // Act
+        let lastRequest = spy.lastRequest
+        
+        // Assert
+        XCTAssert(lastRequest === secondRequest)
+    }
+    
     // MARK: - Response
     
     func testExecute_callsOnComplete_withStoredResponses() {

--- a/Tests/ACInteractorTests/InteractorSpyTests.swift
+++ b/Tests/ACInteractorTests/InteractorSpyTests.swift
@@ -128,4 +128,44 @@ class InteractorSpyTests: XCTestCase {
         XCTAssert(secondRequestError === testError)
     }
     
+    // MARK: - Request Count
+    
+    func testIsCalledOnce_returnsTrue_whenCalledOnce() {
+        var testData = [(executionCalls: Int, result: Bool)]()
+        testData.append((executionCalls: 0, result: false))
+        testData.append((executionCalls: 1, result: true))
+        testData.append((executionCalls: 2, result: false))
+        
+        for test in testData {
+            // Arrange
+            for _ in 0..<test.executionCalls {
+                spy.execute(firstRequest)
+            }
+            
+            // Act
+            let isCalledOnce = spy.isCalledOnce
+            
+            // Assert
+            XCTAssertEqual(isCalledOnce, test.result)
+        }
+    }
+    
+    func testIsNeverCalled_returnsTrue_whenNeverCalled() {
+        var testData = [(executionCalls: Int, result: Bool)]()
+        testData.append((executionCalls: 0, result: true))
+        testData.append((executionCalls: 1, result: false))
+        
+        for test in testData {
+            // Arrange
+            for _ in 0..<test.executionCalls {
+                spy.execute(firstRequest)
+            }
+            
+            // Act
+            let isCalledOnce = spy.isNeverCalled
+            
+            // Assert
+            XCTAssertEqual(isCalledOnce, test.result)
+        }
+    }
 }

--- a/Tests/ACInteractorTests/InteractorSpyTests.swift
+++ b/Tests/ACInteractorTests/InteractorSpyTests.swift
@@ -10,11 +10,30 @@ class InteractorSpyTests: XCTestCase {
     
     let firstRequest = SampleRequest()
     let secondRequest = SampleRequest()
-    let firstResponse = SampleResponse()
-    let secondResponse = SampleResponse()
+    
+    var firstRequestResponse: SampleResponse?
+    var secondRequestResponse: SampleResponse?
+    var firstRequestError: InteractorError?
+    var secondRequestError: InteractorError?
     
     override func setUp() {
         super.setUp()
+        
+        firstRequest.onComplete = { response in
+            self.firstRequestResponse = response
+        }
+        
+        firstRequest.onError = { error in
+            self.firstRequestError = error
+        }
+        
+        secondRequest.onComplete = { response in
+            self.secondRequestResponse = response
+        }
+        
+        secondRequest.onError = { error in
+            self.secondRequestError = error
+        }
     }
     
     // MARK: - Requests
@@ -35,6 +54,36 @@ class InteractorSpyTests: XCTestCase {
     
     // MARK: - Response
     
+    func testExecute_callsOnComplete_withStoredResponses() {
+        // Arrange
+        let firstResponse = SampleResponse()
+        let secondResponse = SampleResponse()
+        spy.returnsResponses = [firstResponse, secondResponse]
+        
+        // Act
+        spy.execute(firstRequest)
+        spy.execute(secondRequest)
+        
+        // Assert
+        XCTAssert(firstRequestResponse === firstResponse)
+        XCTAssert(secondRequestResponse === secondResponse)
+    }
+    
     // MARK: - Error Handling
+    
+    func testExecute_callsOnError_withStoredErrors() {
+        // Arrange
+        let firstError = InteractorError()
+        let secondError = InteractorError()
+        spy.returnsErrors = [firstError, secondError]
+        
+        // Act
+        spy.execute(firstRequest)
+        spy.execute(secondRequest)
+        
+        // Assert
+        XCTAssert(firstRequestError === firstError)
+        XCTAssert(secondRequestError === secondError)
+    }
     
 }


### PR DESCRIPTION
Added a new generic class `InteractorSpy` to simplify the mocking of Interactors for unit tests.
The spy can be specialized by a concrete `InteractorRequest` and mocks the behavior of an Interactor for the given request type.

It stores the incoming requests for later validation and can be trained to return certain responses and errors.

It can be used to easily replace a given Interactor for unit testing.